### PR TITLE
Removed deprecated url to support Django 4.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+Version 2.0.5
+-------------
+
+**Improvement**
+- Refactor to work with Django 4.2 and Python 3.9
+
 Version 2.0.4
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ url is handled by the shortening backend.
 Requirements
 ------------
 
-- python 3.6
-- django 1.11
+- python 3.9
+- django 4.2
 
 
 Installation

--- a/brevisurl/__init__.py
+++ b/brevisurl/__init__.py
@@ -2,7 +2,7 @@ import traceback
 from io import StringIO
 
 
-__versionstr__ = '2.0.4'
+__versionstr__ = '2.0.5'
 
 
 def get_connection(backend=None, fail_silently=False, **kwargs):

--- a/brevisurl/urls.py
+++ b/brevisurl/urls.py
@@ -1,9 +1,13 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 import brevisurl.settings
 from brevisurl import views
 
 
 urlpatterns = [
-    url(brevisurl.settings.LOCAL_BACKEND_URL_PATTERN, views.BrevisUrlRedirectView.as_view(), name='brevisurl_redirect'),
+    re_path(
+        brevisurl.settings.LOCAL_BACKEND_URL_PATTERN,
+        views.BrevisUrlRedirectView.as_view(),
+        name='brevisurl_redirect'
+    ),
 ]


### PR DESCRIPTION
Change
- Removed deprecated django url, and replace with re_path